### PR TITLE
Improve compression by converting the u8array to base64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1640,6 +1640,11 @@
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true
         },
+        "base64-u8array-arraybuffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/base64-u8array-arraybuffer/-/base64-u8array-arraybuffer-1.0.3.tgz",
+            "integrity": "sha512-ZmZagcnyoFih3rtYTMVO0tvAxKkjIf7XOsNV90LeHDZrCx12hcZ+cno8PlvQDRhAa10Fw7j6OYdigzQtBBD65g=="
+        },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "NoledgeBin is a zero-knowledge pastebin",
     "main": "index.html",
     "dependencies": {
+        "base64-u8array-arraybuffer": "^1.0.3",
         "crypto-js": "^4.1.1",
         "crypto-random-string": "^4.0.0",
         "fflate": "^0.7.1",

--- a/resources/app.js
+++ b/resources/app.js
@@ -2,6 +2,7 @@
 
 import * as fflate from 'fflate';
 import * as CryptoJS from 'crypto-js';
+import { base64ToUint8Array, uint8ArrayToBase64 } from 'base64-u8array-arraybuffer';
 
 // cryptoRandomString is async.
 import 'regenerator-runtime/runtime';
@@ -36,10 +37,12 @@ window.sendPaste = function sendPaste() {
         const buf = fflate.strToU8(paste.text);
 
         // Convert the compressed paste to string before storing it.
-        // Later we're stringifying this object, if we don't convert
-        // it to string here then JSON.stringify will preserve the
-        // Array structure, using much more space.
-        paste.text = fflate.compressSync(buf, { level: 6, mem: 8 }).toString();
+        // And we convert it to base64, if we don't convert it here
+        // then JSON.stringify will preserve the Array structure,
+        // using much more space.
+        paste.text = uint8ArrayToBase64(
+            fflate.compressSync(buf, { level: 6, mem: 8 })
+        );
     }
 
     // Convert paste to string before encrypting it.
@@ -86,7 +89,7 @@ function initialize() {
             // converting paste.text to Array. It was converted to
             // string so the Array structure was not preserved.
             const decompressed = fflate.decompressSync(
-                Uint8Array.from(paste.text.split(',').map(Number))
+                base64ToUint8Array(paste.text)
             );
 
             // Store decompressed text.


### PR DESCRIPTION
Earlier we were converting it to string with .toString() but that
would add ',' after each element and that was starting to add up.

According to my tests on 100 paragraphs of lorem ipsum, containing
20559 characters.

- Compressing (and using .toString()) this string and encrypting it,
  the url was about 31268 characters.

- Storing it without compression, the url was about 27812 characters.

In this case, compression was not helping us.

- Storing it by converting u8array to base64, the url was about 11748
  characters.

That's more than 3x improvement.