### PR TITLE
Add top navigation bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,14 @@
         </div>
 
         <div class="wrapper">
+            <div id="top-nav-bar">
+                <button id="new-button" onclick="newPaste();">New Paste</button>
+                <button id="clone-button" onclick="clonePaste();">Clone</button>
+                <button id="send-button" onclick="sendPaste();">Send</button>
+            </div>
             <div class="paste-box-wrapper">
                 <p id="note-above-paste-box" class="hidden"></p>
                 <div id="user-paste" class="paste-box" contenteditable="false"></div>
-                <button id="paste-send-button" class="hidden" onclick="sendPaste();">Send</button>
-                <button id="paste-new-button" class="hidden" onclick="newPaste();">New Paste</button>
             </div>
         </div>
 

--- a/resources/app.js
+++ b/resources/app.js
@@ -9,10 +9,6 @@ import cryptoRandomString from 'crypto-random-string';
 
 // Paste Elements /////////////////////////////////////////////////////////////
 const pasteBox = document.getElementById('user-paste');
-
-const pasteSendButton = document.getElementById('paste-send-button');
-const pasteNewButton = document.getElementById('paste-new-button');
-
 const noteAbovePasteBox = document.getElementById('note-above-paste-box');
 
 window.newPaste = function newPaste() {
@@ -64,9 +60,6 @@ window.sendPaste = function sendPaste() {
     noteAbovePasteBox.classList.add("success");
 
     pasteBox.setAttribute('contenteditable', false);
-
-    pasteSendButton.classList.add("hidden");
-    pasteNewButton.classList.remove("hidden");
 }
 
 function initialize() {
@@ -100,11 +93,7 @@ function initialize() {
         noteAbovePasteBox.innerText = "Paste successfully decrypted.";
         noteAbovePasteBox.classList.remove("failure", "hidden");
         noteAbovePasteBox.classList.add("success");
-
-        pasteNewButton.classList.remove("hidden");
-    } else {
+    } else
         pasteBox.setAttribute('contenteditable', true);
-        pasteSendButton.classList.remove("hidden");
-    }
 }
 initialize();

--- a/resources/style.css
+++ b/resources/style.css
@@ -175,25 +175,32 @@ a:visited:hover, a:visited:focus {
     overflow-wrap: anywhere;
 }
 
-.paste-box-wrapper button {
+#top-nav-bar {
+    background-color: var(--bg-dim);
+    margin: 1ch 0;
+}
+#top-nav-bar button {
     background-color: var(--blue-subtle-bg);
     color: var(--fg-main);
-    padding: 0.8em 1.6em;
+    padding: 0.64em 1.2em;
+    margin: 1ch 0;
     border: 1px solid var(--fg-alt);
-    margin-top: 20px;
+}
+/* Override send button styles */
+#send-button {
+    background-color: var(--cyan-subtle-bg) !important;
     float: right;
 }
 
-.success {
-    background-color: var(--green-subtle-bg);
+#note-above-paste-box {
     padding: 1ch;
     overflow-wrap: break-word;
+}
+.success {
+    background-color: var(--green-subtle-bg);
 }
 
 .failure {
     background-color: var(--red-subtle-bg);
-    padding: 1ch;
-    overflow-wrap: break-word;
 }
-
 .hidden { display:none; }


### PR DESCRIPTION
From https://github.com/noledgebin/frontend/issues/13:

    Below the header bar, we could add a navbar. Currently we only
    have a "Send" button, when we add extra functionality, we'll
    require some space for those options.

    For example, we could add a "Clone" button which will allow the
    user to clone the paste's contents to be able to edit it, easily.
    It'll be better if we keep these on top