### PR TITLE
Fix formatting when pasting

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,8 @@
             </div>
             <div class="paste-box-wrapper">
                 <p id="note-above-paste-box" class="hidden"></p>
-                <div id="user-paste" class="paste-box" contenteditable="false"></div>
+                <textarea id="user-paste" class="paste-box" rows="16"></textarea>
+                <pre id="user-paste-rendered" class="paste-box hidden"></pre>
             </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
                 <button id="send-button" onclick="sendPaste();">Send</button>
             </div>
             <div class="paste-box-wrapper">
-                <p id="note-above-paste-box" class="hidden"></p>
-                <textarea id="user-paste" class="paste-box" rows="16"></textarea>
-                <pre id="user-paste-rendered" class="paste-box hidden"></pre>
+                <p id="note-above-paste-box" style="display:none"></p>
+                <textarea id="user-paste" rows="16"></textarea>
+                <pre id="user-paste-rendered" style="display:none"></pre>
             </div>
         </div>
 

--- a/resources/app.js
+++ b/resources/app.js
@@ -69,10 +69,13 @@ window.sendPaste = function sendPaste() {
     // Show rendered text.
     pasteBox.style.display = 'none';
     pasteBoxRendered.style.display = '';
-    pasteBoxRendered.innerHTML = paste.text;
+    pasteBoxRendered.innerHTML = pasteBox.value;
 }
 
 function initialize() {
+    // Clean the pasteBox.
+    pasteBox.value = '';
+
     const fragment = window.location.hash.substr(1).split('#');
 
     // Paste & Encryption key in fragment URL.

--- a/resources/app.js
+++ b/resources/app.js
@@ -9,19 +9,14 @@ import cryptoRandomString from 'crypto-random-string';
 
 // Paste Elements.
 const pasteBox = document.getElementById('user-paste');
+const pasteBoxRendered = document.getElementById('user-paste-rendered');
 const noteAbovePasteBox = document.getElementById('note-above-paste-box');
 
-// Add event listener to user-paste to strip formatting.
-function handlePasting (e) {
-    // Stop data actually being pasted into div.
-    e.stopPropagation();
-    e.preventDefault();
-
-    // Get pasted data via clipboard API.
-    let clipboardData = e.clipboardData || window.clipboardData;
-    pasteBox.innerText = clipboardData.getData('Text');
+function displaySuccessNote() {
+    noteAbovePasteBox.classList.add("success");
+    noteAbovePasteBox.classList.remove("failure");
+    noteAbovePasteBox.style.display = '';
 }
-pasteBox.addEventListener('paste', handlePasting);
 
 window.newPaste = function newPaste() {
     // Remove fragment url.
@@ -35,8 +30,8 @@ window.newPaste = function newPaste() {
 window.sendPaste = function sendPaste() {
     const passphrase = cryptoRandomString({length: 32, type: 'url-safe'});
     let paste = {
-        "text": pasteBox.innerText,
-        "compressed": pasteBox.innerText.length <= 72 ? false : true
+        "text": pasteBox.value,
+        "compressed": pasteBox.value.length <= 72 ? false : true
     };
 
     if (paste.compressed) {
@@ -67,12 +62,14 @@ window.sendPaste = function sendPaste() {
     let link = document.createElement('a');
     link.setAttribute('href', './#' + pasteUrl);
     link.innerText = '#' + pasteUrl;
+
     noteAbovePasteBox.appendChild(link);
+    displaySuccessNote();
 
-    noteAbovePasteBox.classList.remove("failure", "hidden");
-    noteAbovePasteBox.classList.add("success");
-
-    pasteBox.setAttribute('contenteditable', false);
+    // Show rendered text.
+    pasteBox.style.display = 'none';
+    pasteBoxRendered.style.display = '';
+    pasteBoxRendered.innerHTML = paste.text;
 }
 
 function initialize() {
@@ -100,13 +97,13 @@ function initialize() {
         }
 
         // Update the text.
-        pasteBox.innerText = paste.text;
+        pasteBox.style.display = 'none';
+        pasteBoxRendered.style.display = '';
+        pasteBoxRendered.innerHTML = paste.text;
 
         // Inform user about the paste.
         noteAbovePasteBox.innerText = "Paste successfully decrypted.";
-        noteAbovePasteBox.classList.remove("failure", "hidden");
-        noteAbovePasteBox.classList.add("success");
-    } else
-        pasteBox.setAttribute('contenteditable', true);
+        displaySuccessNote();
+    }
 }
 initialize();

--- a/resources/app.js
+++ b/resources/app.js
@@ -7,9 +7,21 @@ import * as CryptoJS from 'crypto-js';
 import 'regenerator-runtime/runtime';
 import cryptoRandomString from 'crypto-random-string';
 
-// Paste Elements /////////////////////////////////////////////////////////////
+// Paste Elements.
 const pasteBox = document.getElementById('user-paste');
 const noteAbovePasteBox = document.getElementById('note-above-paste-box');
+
+// Add event listener to user-paste to strip formatting.
+function handlePasting (e) {
+    // Stop data actually being pasted into div.
+    e.stopPropagation();
+    e.preventDefault();
+
+    // Get pasted data via clipboard API.
+    let clipboardData = e.clipboardData || window.clipboardData;
+    pasteBox.innerText = clipboardData.getData('Text');
+}
+pasteBox.addEventListener('paste', handlePasting);
 
 window.newPaste = function newPaste() {
     // Remove fragment url.
@@ -19,6 +31,7 @@ window.newPaste = function newPaste() {
     window.location.reload();
 }
 
+// sendPaste reads data from pasteBox and acts on it.
 window.sendPaste = function sendPaste() {
     const passphrase = cryptoRandomString({length: 32, type: 'url-safe'});
     let paste = {

--- a/resources/style.css
+++ b/resources/style.css
@@ -167,19 +167,30 @@ a:visited:hover, a:visited:focus {
 
 /* Paste box *****************************************************************/
 
-.paste-box-wrapper .paste-box {
+.paste-box-wrapper textarea {
     padding: 1ch;
     min-height: 32vh;
-    background-color: var(--bg-alt);
-    border: 1px solid var(--bg-hl-alt-intense);
-    overflow-wrap: anywhere;
-}
-.paste-box-wrapper textarea {
     width: 100%;
     resize: vertical;
     vertical-align:top;
-    color: var(--fg-main);
     font-size: 0.96rem;
+
+    color: var(--fg-main);
+    background-color: var(--bg-alt);
+    border: 1px solid var(--bg-hl-alt-intense);
+
+}
+.paste-box-wrapper pre {
+    padding: 0.6em;
+    display: block;
+    overflow-x: auto;
+    white-space: pre;
+    word-break: break-all;
+    font-size: 0.96rem;
+
+    color: var(--fg-main);
+    background-color: var(--bg-alt);
+    border: 1px solid var(--bg-hl-alt-intense);
 }
 
 #top-nav-bar {
@@ -210,4 +221,3 @@ a:visited:hover, a:visited:focus {
 .failure {
     background-color: var(--red-subtle-bg);
 }
-.hidden { display:none; }

--- a/resources/style.css
+++ b/resources/style.css
@@ -169,7 +169,7 @@ a:visited:hover, a:visited:focus {
 
 .paste-box-wrapper textarea {
     padding: 1ch;
-    min-height: 32vh;
+    height: 64vh;
     width: 100%;
     resize: vertical;
     vertical-align:top;
@@ -180,12 +180,12 @@ a:visited:hover, a:visited:focus {
     border: 1px solid var(--bg-hl-alt-intense);
 
 }
-.paste-box-wrapper pre {
+pre {
     padding: 0.6em;
     display: block;
     overflow-x: auto;
-    white-space: pre;
-    word-break: break-all;
+    white-space: pre-wrap;
+    word-wrap: break-word;
     font-size: 0.96rem;
 
     color: var(--fg-main);

--- a/resources/style.css
+++ b/resources/style.css
@@ -169,10 +169,17 @@ a:visited:hover, a:visited:focus {
 
 .paste-box-wrapper .paste-box {
     padding: 1ch;
-    min-height: 72vh;
+    min-height: 32vh;
     background-color: var(--bg-alt);
     border: 1px solid var(--bg-hl-alt-intense);
     overflow-wrap: anywhere;
+}
+.paste-box-wrapper textarea {
+    width: 100%;
+    resize: vertical;
+    vertical-align:top;
+    color: var(--fg-main);
+    font-size: 0.96rem;
 }
 
 #top-nav-bar {


### PR DESCRIPTION
Fixes https://github.com/noledgebin/frontend/issues/19.

This moves to using `textarea` instead of `contenteditable` `div`.

From https://github.com/noledgebin/frontend/issues/19#issuecomment-956036441:

> Using `contenteditable` is a bad idea. To fix this you need to strip formatting, figure out cursor's location and then add the data at that position. It adds to complexity without any benefits.